### PR TITLE
Penrose docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+.stack-work

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu
+
+RUN apt-get update
+
+RUN apt-get install -y curl
+RUN curl -sSL https://get.haskellstack.org/ | sh
+ENV PATH=/root/.local/bin:${PATH}
+RUN stack install happy
+
+COPY stack.yaml penrose.cabal /penrose/
+WORKDIR /penrose
+RUN stack --jobs 1 build --dependencies-only  # Without --jobs 1 this runs out of memory in a 2GB container.
+
+COPY src /penrose/src
+COPY test /penrose/test
+COPY ChangeLog.md LICENSE README.md /penrose/
+RUN stack install --ghc-options '-optl-static -fPIC'  # statically linked penrose executable
+
+FROM alpine
+
+COPY src /penrose/src
+COPY --from=0 /root/.local/bin/penrose /usr/local/bin/penrose
+
+# -- To use the alloy java library, change the `FROM alpine` line to this:
+# FROM openjdk:8-alpine
+# -- And uncomment the following:
+# WORKDIR /penrose/src
+# RUN apk add --update make
+# RUN make -B
+
+RUN apk add --update mini_httpd
+
+EXPOSE 8000 9160
+
+WORKDIR /penrose
+
+COPY docker/entrypoint /penrose/entrypoint
+ENTRYPOINT ["/penrose/entrypoint"]
+CMD ["/penrose/src/linear-algebra-domain/vectorsAddition.sub", \
+     "/penrose/src/linear-algebra-domain/linear-algebra.sty", \
+     "/penrose/src/linear-algebra-domain/linear-algebra.dsl"]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,32 @@
+IMAGE_NAME:=penrose
+CONTAINER_NAME:=$(IMAGE_NAME)
+
+# TODO: use repo belonging to penrose project
+REPO:=dandavison7
+
+
+.PHONY: build
+build: Dockerfile
+	docker build --file Dockerfile --tag $(IMAGE_NAME) ..
+
+
+.PHONY: push
+push: build
+	docker tag $(IMAGE_NAME) $(REPO)/$(IMAGE_NAME)
+	docker push $(REPO)/$(IMAGE_NAME)
+
+
+.PHONY: pull
+pull:
+	docker pull $(REPO)/$(IMAGE_NAME)
+	docker tag $(REPO)/$(IMAGE_NAME) $(IMAGE_NAME)
+
+
+.PHONY: run-shell
+run-shell: build
+	docker run -it -p 8000:8000 -p 9160:9160 --entrypoint sh $(IMAGE_NAME)
+
+
+.PHONY: exec-shell
+exec-shell:
+	docker exec -it $(CONTAINER_NAME) sh

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,54 @@
+## Getting started
+
+**To quickly try out penrose you can pull the docker image without needing to compile the code:**
+
+1. Install [docker](https://www.docker.com/products/docker-desktop)
+2. Run the following command:
+   ```sh
+   docker run -it -p 8000:8000 -p 9160:9160 dandavison7/penrose
+   ```
+3. Visit http://localhost:8000/client.html in a web browser and click on "Autostep".
+
+
+To make the following commands more convenient let's rename the local docker image:
+```
+docker tag dandavison7/penrose penrose
+```
+
+**The docker image has several other linear algebra examples:**
+
+For example:
+```
+docker run -it -p 8000:8000 -p 9160:9160 penrose \
+    src/linear-algebra-domain/determinants.sub \
+    src/linear-algebra-domain/linear-algebra.sty \
+    src/linear-algebra-domain/linear-algebra.dsl
+```
+
+Look in the
+[src/linear-algebra-domain/](https://github.com/penrose/penrose/tree/master/src/linear-algebra-domain)
+directory for more examples.
+
+
+## Running your own `.sub`, `.sty`, and `.dsl` files
+
+To run your own `.sub`, `.sty`, and `.dsl` files you need to supply a few more arguments to mount your home directory inside the docker container:
+
+```
+docker run -it -p 8000:8000 -p 9160:9160 --volume=$HOME/:$HOME/ --workdir $PWD penrose \
+    /path/to/my.sub \
+    /path/to/my.sty \
+    /path/to/my.dsl
+```
+
+To make this more convenient there's a shell script `docker/bin/penrose` in the git repository.
+
+
+## For Penrose developers:
+
+To build the image:
+```
+cd docker
+make build
+```
+Issuing `make build` again after modifying the code in `src/` will trigger re-compilation of the `penrose` executable but not of the Haskell dependencies.

--- a/docker/bin/penrose
+++ b/docker/bin/penrose
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+docker run \
+       --interactive \
+       --tty \
+       --name penrose \
+       --rm \
+       --volume=/tmp/:/tmp/ \
+       --volume=$HOME/:$HOME/ \
+       --workdir $PWD \
+       -p 8000:8000 -p 9160:9160 \
+       penrose $@

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+(cd /penrose/src/front-end && mini_httpd -p 8000 &)
+exec penrose "$@"

--- a/src/ShadowMain.hs
+++ b/src/ShadowMain.hs
@@ -130,7 +130,9 @@ shadowMain = do
     -- pPrint finalState
 
     -- Starting serving penrose on the web
-    let (domain, port) = ("127.0.0.1", 9160)
+    -- The server needs to listen on 0.0.0.0 when running in a docker container.
+    -- TODO: make this a command-line option, defaulting to localhost.
+    let (domain, port) = ("0.0.0.0", 9160)
     Server.servePenrose domain port initState
 
 -- Versions of main for the tests to use that takes arguments internally, and returns initial and final state


### PR DESCRIPTION
*This PR does not target the [public penrose repo](https://github.com/penrose/penrose).* 

These two commits add the ability to run Penrose in a docker container.

The final docker image is small (31.5MB). This allows anyone to try out Penrose quickly with a single command (~5 seconds with my current network connection):

```
docker run -it -p 8000:8000 -p 9160:9160 dandavison7/penrose
```

The Dockerfile builds an intermediate image containing the Haskell build environment. Since this is very bulky, it is not included in the final image. However, a developer who builds the image locally will have all layers cached for both images. Changes to the Haskell source code trigger a rebuild which compiles the Penrose executable, without recompiling dependencies.

Installation of the Java build and runtime environment are commented out in the Dockerfile since the alloy library was not being used at the time of writing.

The README gives instructions for:

1. Pulling the Penrose docker image and running the container against the provided examples in the `linear-algebra-domain` directory.
2. Running against user-supplied language files via a host directory mounted into the container.
3. Building the image as a developer.

All the changes are inside a top-level `docker/` directory.
